### PR TITLE
feat: simplify case identifier validation to accept any alphanumeric …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,9 +59,9 @@ YaFT includes built-in support for forensic case identifier management. The CLI 
 
 ### Case Identifier Formats
 
-- **Examiner ID**: User/investigator identifier (format: alphanumeric with underscores/hyphens, 2-50 characters - e.g., `john_doe`, `examiner-123`)
-- **Case ID**: Case number (format: 4+ uppercase alphanumeric characters, dash, 2+ digits - e.g., `CASE2024-01`)
-- **Evidence ID**: Evidence number (format: 2-4 uppercase letters, 4-8 digits, dash, 1-2 digits - e.g., `EV123456-01`)
+- **Examiner ID**: User/investigator identifier (alphanumeric with underscores/hyphens, 2-50 characters - e.g., `john_doe`, `examiner-123`)
+- **Case ID**: Case number (any alphanumeric string - e.g., `CASE2024-01`, `Case123`, `MyCase`)
+- **Evidence ID**: Evidence number (any alphanumeric string - e.g., `BG123456-1`, `Evidence1`, `Ev-001`)
 
 ### Core API Methods
 

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ python -m yaft.cli --version
 YAFT includes built-in support for forensic case management. When running plugins, the tool prompts for case identifiers that are automatically included in reports and used to organize output files.
 
 **Case Identifier Formats:**
-- **Examiner ID**: User/investigator identifier (format: alphanumeric with underscores/hyphens, 2-50 characters - e.g., `john_doe`, `examiner-123`)
-- **Case ID**: Case number (format: 4+ uppercase alphanumeric characters, dash, 2+ digits - e.g., `CASE2024-01`)
-- **Evidence ID**: Evidence number (format: 2-4 uppercase letters, 4-8 digits, dash, 1-2 digits - e.g., `EV123456-01`)
+- **Examiner ID**: User/investigator identifier (alphanumeric with underscores/hyphens, 2-50 characters - e.g., `john_doe`, `examiner-123`)
+- **Case ID**: Case number (any alphanumeric string - e.g., `CASE2024-01`, `Case123`, `MyCase`)
+- **Evidence ID**: Evidence number (any alphanumeric string - e.g., `BG123456-1`, `Evidence1`, `Ev-001`)
 
 **Example Usage:**
 ```bash

--- a/src/yaft/core/api.py
+++ b/src/yaft/core/api.py
@@ -199,31 +199,31 @@ class CoreAPI:
 
     def validate_case_id(self, value: str) -> bool:
         """
-        Validate Case ID format: uppercase alphanumeric with optional dash and numbers.
-        Examples: CASE2024-01, K2024001-01, 2024-001
+        Validate Case ID format: any alphanumeric string.
+        Examples: CASE2024-01, K2024001-01, 2024-001, Case123, MyCase
 
         Args:
             value: Case ID to validate
 
         Returns:
-            bool: True if valid, False otherwise
+            bool: True if valid (any non-empty alphanumeric string), False otherwise
         """
         import re
-        return bool(re.match(r'^[A-Z0-9]{4,}-[0-9]{2,}$', value))
+        return bool(re.match(r'^[A-Za-z0-9_-]+$', value))
 
     def validate_evidence_id(self, value: str) -> bool:
         """
-        Validate Evidence ID format: 2-4 uppercase letters followed by 4-8 digits, dash, 1-2 digits.
-        Examples: BG123456-1, EV123456-1, ITEM1234-01
+        Validate Evidence ID format: any alphanumeric string.
+        Examples: BG123456-1, EV123456-1, ITEM1234-01, Evidence1, Ev-001
 
         Args:
             value: Evidence ID to validate
 
         Returns:
-            bool: True if valid, False otherwise
+            bool: True if valid (any non-empty alphanumeric string), False otherwise
         """
         import re
-        return bool(re.match(r'^[A-Z]{2,4}[0-9]{4,8}-[0-9]{1,2}$', value))
+        return bool(re.match(r'^[A-Za-z0-9_-]+$', value))
 
     def prompt_for_case_identifiers(self) -> tuple[str, str, str]:
         """
@@ -247,19 +247,17 @@ class CoreAPI:
 
         # Prompt for Case ID
         while True:
-            case_id = self.console.input("[bold cyan]?[/bold cyan] Case ID (format: CASE2024-01): ").strip()
+            case_id = self.console.input("[bold cyan]?[/bold cyan] Case ID (alphanumeric): ").strip()
             if self.validate_case_id(case_id):
-                case_id = case_id.upper()  # Normalize to uppercase
                 break
-            self.console.print("[bold red]✗[/bold red] Invalid format. Expected: 4+ uppercase alphanumeric, dash, 2+ digits (e.g., CASE2024-01, K2024001-01)")
+            self.console.print("[bold red]✗[/bold red] Invalid format. Use alphanumeric characters, underscores, or hyphens (e.g., CASE2024-01, Case123, MyCase)")
 
         # Prompt for Evidence ID
         while True:
-            evidence_id = self.console.input("[bold cyan]?[/bold cyan] Evidence ID (format: BG123456-1): ").strip()
+            evidence_id = self.console.input("[bold cyan]?[/bold cyan] Evidence ID (alphanumeric): ").strip()
             if self.validate_evidence_id(evidence_id):
-                evidence_id = evidence_id.upper()  # Normalize to uppercase
                 break
-            self.console.print("[bold red]✗[/bold red] Invalid format. Expected: 2-4 letters, 4-8 digits, dash, 1-2 digits (e.g., BG123456-1, EV1234-01)")
+            self.console.print("[bold red]✗[/bold red] Invalid format. Use alphanumeric characters, underscores, or hyphens (e.g., BG123456-1, Evidence1, Ev-001)")
 
         # Store identifiers
         self._examiner_id = examiner_id
@@ -294,20 +292,16 @@ class CoreAPI:
         Raises:
             ValueError: If any identifier has invalid format
         """
-        # Normalize case_id and evidence_id to uppercase before validation
-        case_id_normalized = case_id.upper()
-        evidence_id_normalized = evidence_id.upper()
-
         if not self.validate_examiner_id(examiner_id):
             raise ValueError(f"Invalid Examiner ID format: {examiner_id}")
-        if not self.validate_case_id(case_id_normalized):
+        if not self.validate_case_id(case_id):
             raise ValueError(f"Invalid Case ID format: {case_id}")
-        if not self.validate_evidence_id(evidence_id_normalized):
+        if not self.validate_evidence_id(evidence_id):
             raise ValueError(f"Invalid Evidence ID format: {evidence_id}")
 
         self._examiner_id = examiner_id
-        self._case_id = case_id_normalized
-        self._evidence_id = evidence_id_normalized
+        self._case_id = case_id
+        self._evidence_id = evidence_id
 
     def get_case_output_dir(self, subdir: str = "") -> Path:
         """

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -439,35 +439,34 @@ def test_validate_examiner_id(core_api):
 
 def test_validate_case_id(core_api):
     """Test Case ID validation."""
-    # Valid formats
+    # Valid formats - any alphanumeric string
     assert core_api.validate_case_id("CASE2024-01") is True
-    assert core_api.validate_case_id("K2024001-01") is True
+    assert core_api.validate_case_id("case2024-01") is True  # Lowercase allowed
+    assert core_api.validate_case_id("Case123") is True
+    assert core_api.validate_case_id("MyCase") is True
     assert core_api.validate_case_id("2024-001") is True
-    assert core_api.validate_case_id("ABCD-99") is True
+    assert core_api.validate_case_id("ABC_DEF-123") is True
 
     # Invalid formats
-    assert core_api.validate_case_id("case2024-01") is False  # Lowercase not allowed
-    assert core_api.validate_case_id("ABC-01") is False  # First part too short
-    assert core_api.validate_case_id("CASE2024-1") is False  # Second part too short
-    assert core_api.validate_case_id("CASE2024") is False  # Missing dash and suffix
-    assert core_api.validate_case_id("CASE-2024-01") is False  # Too many dashes
+    assert core_api.validate_case_id("") is False  # Empty string
+    assert core_api.validate_case_id("CASE 2024") is False  # Spaces not allowed
+    assert core_api.validate_case_id("CASE@2024") is False  # Special chars not allowed
 
 
 def test_validate_evidence_id(core_api):
     """Test Evidence ID validation."""
-    # Valid formats
+    # Valid formats - any alphanumeric string
     assert core_api.validate_evidence_id("BG123456-1") is True
-    assert core_api.validate_evidence_id("EV123456-01") is True
-    assert core_api.validate_evidence_id("ITEM1234-1") is True
-    assert core_api.validate_evidence_id("AB1234-99") is True
+    assert core_api.validate_evidence_id("bg123456-1") is True  # Lowercase allowed
+    assert core_api.validate_evidence_id("Evidence1") is True
+    assert core_api.validate_evidence_id("Ev-001") is True
+    assert core_api.validate_evidence_id("ITEM_ABC-123") is True
+    assert core_api.validate_evidence_id("MyEvidence") is True
 
     # Invalid formats
-    assert core_api.validate_evidence_id("bg123456-1") is False  # Lowercase not allowed
-    assert core_api.validate_evidence_id("A123456-1") is False  # Letter part too short
-    assert core_api.validate_evidence_id("ABCDE123456-1") is False  # Letter part too long
-    assert core_api.validate_evidence_id("BG123-1") is False  # Number part too short
-    assert core_api.validate_evidence_id("BG123456-123") is False  # Suffix too long
-    assert core_api.validate_evidence_id("BG123456") is False  # Missing dash and suffix
+    assert core_api.validate_evidence_id("") is False  # Empty string
+    assert core_api.validate_evidence_id("BG 123456") is False  # Spaces not allowed
+    assert core_api.validate_evidence_id("BG@123456") is False  # Special chars not allowed
 
 
 def test_set_and_get_case_identifiers(core_api):
@@ -482,15 +481,15 @@ def test_set_and_get_case_identifiers(core_api):
 
 
 def test_set_case_identifiers_normalization(core_api):
-    """Test case identifier normalization."""
-    # Case ID and Evidence ID should be uppercase
+    """Test case identifier storage (no normalization)."""
+    # Identifiers should be stored as-is (no uppercasing)
     core_api.set_case_identifiers("john_doe", "case2024-01", "bg999888-7")
 
     examiner, case, evidence = core_api.get_case_identifiers()
 
-    assert examiner == "john_doe"  # Kept as-is
-    assert case == "CASE2024-01"  # Normalized to uppercase
-    assert evidence == "BG999888-7"  # Normalized to uppercase
+    assert examiner == "john_doe"
+    assert case == "case2024-01"  # Stored as-is
+    assert evidence == "bg999888-7"  # Stored as-is
 
 
 def test_set_case_identifiers_invalid(core_api):
@@ -499,10 +498,10 @@ def test_set_case_identifiers_invalid(core_api):
         core_api.set_case_identifiers("x", "CASE2024-01", "BG123456-1")
 
     with pytest.raises(ValueError, match="Invalid Case ID"):
-        core_api.set_case_identifiers("examiner01", "invalid", "BG123456-1")
+        core_api.set_case_identifiers("examiner01", "invalid@case", "BG123456-1")  # @ not allowed
 
     with pytest.raises(ValueError, match="Invalid Evidence ID"):
-        core_api.set_case_identifiers("examiner01", "CASE2024-01", "invalid")
+        core_api.set_case_identifiers("examiner01", "CASE2024-01", "invalid@ev")  # @ not allowed
 
 
 def test_get_case_output_dir_with_identifiers(core_api):

--- a/uv.lock
+++ b/uv.lock
@@ -536,7 +536,7 @@ wheels = [
 
 [[package]]
 name = "yaft"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
…string

- Changed validate_case_id() and validate_evidence_id() to accept any alphanumeric string
- Removed strict format requirements (uppercase, specific patterns)
- Removed automatic uppercasing in set_case_identifiers() and prompt_for_case_identifiers()
- Updated documentation (README.md, CLAUDE.md) to reflect simplified validation
- Updated tests to validate new flexible format rules

This makes the tool more flexible for different forensic workflows and naming conventions.