### PR TITLE
feat: enhance ZIP format detection for Android extractions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ nul
 
 # Claude files (local development only)
 .claude/
+
+¤ Research files
+research/

--- a/tests/test_android_call_log_analyzer.py
+++ b/tests/test_android_call_log_analyzer.py
@@ -173,7 +173,7 @@ def test_detect_zip_structure_cellebrite(plugin, core_api, mock_android_zip_cell
     core_api.set_zip_file(mock_android_zip_cellebrite)
     plugin._detect_zip_structure()
 
-    assert plugin.extraction_type == "cellebrite"
+    assert plugin.extraction_type == "cellebrite_android"
     assert plugin.zip_prefix == "fs/"
 
 
@@ -182,7 +182,7 @@ def test_detect_zip_structure_graykey(plugin, core_api, mock_android_zip_graykey
     core_api.set_zip_file(mock_android_zip_graykey)
     plugin._detect_zip_structure()
 
-    assert plugin.extraction_type == "graykey"
+    assert plugin.extraction_type == "graykey_android"
     assert plugin.zip_prefix == ""
 
 

--- a/tests/test_ios_call_log_analyzer.py
+++ b/tests/test_ios_call_log_analyzer.py
@@ -177,7 +177,7 @@ def test_detect_zip_structure_cellebrite(plugin, core_api, mock_ios_zip_cellebri
     core_api.set_zip_file(mock_ios_zip_cellebrite)
     plugin._detect_zip_structure()
 
-    assert plugin.extraction_type == "cellebrite"
+    assert plugin.extraction_type == "cellebrite_ios"
     assert plugin.zip_prefix == "filesystem1/"
 
 
@@ -186,7 +186,7 @@ def test_detect_zip_structure_graykey(plugin, core_api, mock_ios_zip_graykey):
     core_api.set_zip_file(mock_ios_zip_graykey)
     plugin._detect_zip_structure()
 
-    assert plugin.extraction_type == "graykey"
+    assert plugin.extraction_type == "graykey_ios"
     assert plugin.zip_prefix == ""
 
 

--- a/tests/test_ios_device_info_extractor.py
+++ b/tests/test_ios_device_info_extractor.py
@@ -322,7 +322,7 @@ def test_export_to_json(plugin, core_api, mock_ios_zip_cellebrite, tmp_path):
     assert data["plugin_name"] == "iOSDeviceInfoExtractor"
     assert data["plugin_version"] == "1.0.0"
     assert "data" in data  # CoreAPI uses "data" key for plugin data
-    assert data["extraction_source"] == "cellebrite"
+    assert data["extraction_source"] == "cellebrite_ios"
 
 
 def test_generate_report(plugin, core_api, mock_ios_zip_cellebrite):

--- a/uv.lock
+++ b/uv.lock
@@ -536,7 +536,7 @@ wheels = [
 
 [[package]]
 name = "yaft"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
- Updated detect_zip_format() to return OS-specific format types:
  - cellebrite_ios, cellebrite_android
  - graykey_ios, graykey_android
- Added support for Cellebrite Android format (Dump/ and extra/ folders)
- Added support for GrayKey Android format (apex/, cache/, data/, etc.)
- Updated format detection to scan root-level folders (first 100 entries)
- Added comprehensive documentation in CLAUDE.md with format table
- Added 10 new tests for all format detection scenarios
- Updated existing plugin tests to expect new format strings
- All 179 tests passing

Supported formats:
- Cellebrite iOS: filesystem1/ or filesystem/ prefix
- Cellebrite Android: Dump/ prefix (or legacy fs/ prefix)
- GrayKey iOS: no prefix (private/, System/, Library/ folders)
- GrayKey Android: no prefix (apex/, data/, system/, cache/ folders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)