### PR TITLE
Add experimental AI/LLM provider abstraction with local Ollama support

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,23 @@ format_type, prefix = self.core_api.detect_zip_format()
 path = self.core_api.normalize_zip_path("data/data/com.example/app.db", prefix)
 ```
 
+### AI Features (Experimental)
+
+YAFT includes an experimental, pluggable LLM provider abstraction. It's plumbing only for now: a working local backend and CLI/config wiring, with no plugin sending case data to a model yet.
+
+- **Local-only by default**: the default provider is Ollama (or any OpenAI-compatible server), so forensic case data stays on the examiner's machine unless a cloud provider is explicitly configured.
+- **Opt-in**: AI features are disabled until you run `yaft ai-configure --enable`. Cloud providers (Anthropic, OpenAI) have config placeholders but are not yet implemented.
+
+```bash
+# Configure and enable the local (Ollama) provider
+python -m yaft.cli ai-configure --provider ollama --model llama3.1:8b --enable
+
+# Check configuration and test connectivity (no case data is sent)
+python -m yaft.cli ai-status
+```
+
+See [docs/YaFT.md](docs/YaFT.md#ai--llm-provider-experimental) for details.
+
 ## Building Executables
 
 ### Prerequisites

--- a/config/ai.toml
+++ b/config/ai.toml
@@ -1,0 +1,32 @@
+# YAFT AI / LLM Provider Configuration
+# This file controls AI feature behavior for YAFT (Yet Another Forensic Tool)
+#
+# AI features are disabled by default. Forensic case data (PII, potentially
+# CSAM, chain-of-custody-bound evidence) often cannot legally leave the
+# examiner's machine, so the default provider is a local, self-hosted
+# backend (Ollama). Cloud providers (Anthropic, OpenAI) are strictly
+# opt-in and are not yet implemented in this release.
+
+[ai]
+# Master switch for all AI features. Even the local backend requires this
+# to be explicitly enabled (via `yaft ai-configure --enable`).
+enabled = false
+
+# Default provider to use: ollama, anthropic, openai
+default_provider = "ollama"
+
+# Local, OpenAI-compatible backend (Ollama, llama.cpp, LM Studio, LocalAI, vLLM)
+[ai.providers.ollama]
+base_url = "http://localhost:11434/v1"
+model = "llama3.1:8b"
+timeout = 60
+
+# Anthropic provider (placeholder - not yet implemented)
+[ai.providers.anthropic]
+enabled = false
+model = "claude-haiku-4-5"
+
+# OpenAI provider (placeholder - not yet implemented)
+[ai.providers.openai]
+enabled = false
+model = "gpt-4o-mini"

--- a/docs/YaFT.md
+++ b/docs/YaFT.md
@@ -1937,6 +1937,31 @@ python build_exe.py
 uv pip install package-name
 ```
 
+## AI / LLM Provider (Experimental)
+
+YAFT includes an experimental, pluggable LLM provider abstraction for future AI-assisted plugins. It ships with a working local backend and configuration/CLI wiring only - no plugin sends case data to a model yet.
+
+**Local-only by default:** the default provider is Ollama (or any OpenAI-compatible server: llama.cpp, LM Studio, LocalAI, vLLM) so forensic case data never has to leave the examiner's machine. Cloud providers (Anthropic, OpenAI) have config placeholders but are not yet implemented - calling them raises a clear error. AI features are disabled by default; even the local backend requires an explicit `yaft ai-configure --enable`.
+
+```bash
+# Configure and enable the local (Ollama) provider
+python -m yaft.cli ai-configure --provider ollama --model llama3.1:8b --enable
+
+# Check configuration and test connectivity (no case data is sent)
+python -m yaft.cli ai-status
+
+# Disable AI features
+python -m yaft.cli ai-configure --disable
+```
+
+Configuration lives in `config/ai.toml`, following the same pattern as `config/plugin_updater.toml`. Programmatic access mirrors `get_plugin_updater()`:
+
+```python
+provider = self.core_api.get_llm_provider()
+if provider.is_available():
+    result = provider.summarize("some text")
+```
+
 ## Plugin Profiles
 
 YaFT supports plugin profiles - TOML configuration files that specify a set of plugins to run together. This makes it easy to perform standard analysis workflows without manually listing plugins each time.

--- a/src/yaft/ai/__init__.py
+++ b/src/yaft/ai/__init__.py
@@ -1,0 +1,1 @@
+"""AI / LLM provider abstraction for YAFT."""

--- a/src/yaft/ai/exceptions.py
+++ b/src/yaft/ai/exceptions.py
@@ -1,0 +1,17 @@
+"""Exceptions raised by the AI / LLM provider layer."""
+
+
+class AIError(Exception):
+    """Base class for AI-related errors."""
+
+
+class AIFeatureDisabledError(AIError):
+    """Raised when AI features are used while disabled in configuration."""
+
+
+class AIProviderNotImplementedError(AIError):
+    """Raised when a configured provider has no implementation yet."""
+
+
+class AIProviderError(AIError):
+    """Raised when a provider call fails (network error, bad response, etc.)."""

--- a/src/yaft/ai/factory.py
+++ b/src/yaft/ai/factory.py
@@ -1,0 +1,41 @@
+"""Factory for building the configured LLM provider."""
+
+from yaft.ai.exceptions import AIFeatureDisabledError, AIProviderNotImplementedError
+from yaft.ai.providers.base import LLMProvider
+from yaft.ai.providers.openai_compatible import OpenAICompatibleProvider
+from yaft.core.ai_config import AIConfig
+
+
+def build_provider(cfg: AIConfig) -> LLMProvider:
+    """
+    Build the LLM provider configured in cfg.default_provider.
+
+    Args:
+        cfg: AI configuration
+
+    Returns:
+        LLMProvider instance for the configured default provider
+
+    Raises:
+        AIFeatureDisabledError: If cfg.enabled is False
+        AIProviderNotImplementedError: If the configured provider has no implementation yet
+    """
+    if not cfg.enabled:
+        raise AIFeatureDisabledError(
+            "AI features are disabled. Run `yaft ai-configure --enable` to turn them on."
+        )
+
+    if cfg.default_provider == "ollama":
+        return OpenAICompatibleProvider(
+            base_url=cfg.ollama.base_url,
+            model=cfg.ollama.model,
+            timeout=cfg.ollama.timeout,
+        )
+
+    if cfg.default_provider in ("anthropic", "openai"):
+        raise AIProviderNotImplementedError(
+            f"Provider '{cfg.default_provider}' is not implemented yet. "
+            "Use 'ollama' for a local, self-hosted backend."
+        )
+
+    raise AIProviderNotImplementedError(f"Unknown provider: {cfg.default_provider}")

--- a/src/yaft/ai/providers/__init__.py
+++ b/src/yaft/ai/providers/__init__.py
@@ -1,0 +1,1 @@
+"""LLM provider implementations."""

--- a/src/yaft/ai/providers/base.py
+++ b/src/yaft/ai/providers/base.py
@@ -1,0 +1,26 @@
+"""Base types shared by all LLM providers."""
+
+from typing import Protocol
+
+from pydantic import BaseModel, Field
+
+
+class LLMResult(BaseModel):
+    """Result of a single LLM call."""
+
+    text: str = Field(..., description="Generated text response")
+    provider: str = Field(..., description="Name of the provider that produced this result")
+    model: str = Field(..., description="Model name used")
+    latency_ms: int = Field(..., description="Call latency in milliseconds")
+
+
+class LLMProvider(Protocol):
+    """Protocol implemented by all LLM providers."""
+
+    def is_available(self) -> bool:
+        """Check whether the provider's backend is reachable."""
+        ...
+
+    def summarize(self, prompt: str, *, system: str | None = None) -> LLMResult:
+        """Send a prompt to the backend and return the generated response."""
+        ...

--- a/src/yaft/ai/providers/openai_compatible.py
+++ b/src/yaft/ai/providers/openai_compatible.py
@@ -1,0 +1,85 @@
+"""LLM provider for any OpenAI-compatible chat completions server.
+
+Covers Ollama, llama.cpp's llama-server, LM Studio, LocalAI, and vLLM with a
+single implementation, since they all speak the same /v1/chat/completions
+wire format.
+"""
+
+import json
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+import requests
+
+from yaft.ai.exceptions import AIProviderError
+from yaft.ai.providers.base import LLMResult
+
+AUDIT_LOG_PATH = Path(".ai_cache") / "audit.jsonl"
+
+
+def _write_audit_log(provider: str, model: str, latency_ms: int, success: bool) -> None:
+    """Append a minimal audit record. Never logs prompt/response content."""
+    try:
+        AUDIT_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "provider": provider,
+            "model": model,
+            "latency_ms": latency_ms,
+            "success": success,
+        }
+        with open(AUDIT_LOG_PATH, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        pass
+
+
+class OpenAICompatibleProvider:
+    """LLM provider that speaks the OpenAI-compatible chat completions API."""
+
+    def __init__(self, base_url: str, model: str, timeout: int = 60) -> None:
+        """
+        Initialize the provider.
+
+        Args:
+            base_url: Base URL of the OpenAI-compatible server (e.g. http://localhost:11434/v1)
+            model: Model name to use
+            timeout: Request timeout in seconds
+        """
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.timeout = timeout
+
+    def is_available(self) -> bool:
+        """Check whether the backend is reachable by querying /models."""
+        try:
+            resp = requests.get(f"{self.base_url}/models", timeout=5)
+            return resp.status_code == 200
+        except requests.RequestException:
+            return False
+
+    def summarize(self, prompt: str, *, system: str | None = None) -> LLMResult:
+        """Send a prompt to the backend and return the generated response."""
+        messages = ([{"role": "system", "content": system}] if system else []) + [
+            {"role": "user", "content": prompt}
+        ]
+
+        start = time.monotonic()
+        try:
+            resp = requests.post(
+                f"{self.base_url}/chat/completions",
+                json={"model": self.model, "messages": messages},
+                timeout=self.timeout,
+            )
+            resp.raise_for_status()
+        except requests.RequestException as e:
+            latency_ms = int((time.monotonic() - start) * 1000)
+            _write_audit_log("ollama", self.model, latency_ms, success=False)
+            raise AIProviderError(f"OpenAI-compatible call failed: {e}") from e
+
+        latency_ms = int((time.monotonic() - start) * 1000)
+        text = resp.json()["choices"][0]["message"]["content"]
+        _write_audit_log("ollama", self.model, latency_ms, success=True)
+
+        return LLMResult(text=text, provider="ollama", model=self.model, latency_ms=latency_ms)

--- a/src/yaft/cli.py
+++ b/src/yaft/cli.py
@@ -7,11 +7,13 @@ Provides command-line interface with color-coded output using Typer and Rich.
 from pathlib import Path
 from typing import Annotated
 
+import toml
 import typer
 from rich.console import Console
 from rich.panel import Panel
 
 from yaft import __version__
+from yaft.ai.exceptions import AIProviderNotImplementedError
 from yaft.core.api import CoreAPI
 from yaft.core.plugin_manager import PluginManager
 
@@ -648,6 +650,119 @@ def list_available_plugins(
 
     except Exception as e:
         console.print(f"\n[red]✗ Failed to list plugins:[/red] {str(e)}")
+        raise typer.Exit(code=1)
+
+
+@app.command(name="ai-configure")
+def ai_configure(
+    provider: Annotated[
+        str,
+        typer.Option("--provider", help="Provider: ollama, anthropic, openai"),
+    ] = "ollama",
+    model: Annotated[
+        str | None,
+        typer.Option("--model", help="Model name"),
+    ] = None,
+    base_url: Annotated[
+        str | None,
+        typer.Option("--base-url", help="Base URL (ollama/openai-compatible only)"),
+    ] = None,
+    enable: Annotated[
+        bool,
+        typer.Option("--enable/--disable", help="Enable or disable AI features"),
+    ] = True,
+) -> None:
+    """
+    Configure the AI provider (writes config/ai.toml).
+
+    AI features default to a local, self-hosted backend (Ollama) since
+    forensic case data often cannot leave the examiner's machine. Cloud
+    providers (anthropic, openai) are not yet implemented.
+
+    Examples:
+        yaft ai-configure --provider ollama --model llama3.1:8b --enable
+        yaft ai-configure --disable
+    """
+    from yaft.core.ai_config import AIConfig, OllamaProviderConfig
+
+    core_api = get_core_api()
+    cfg = core_api._ai_config
+
+    ollama_cfg = OllamaProviderConfig(
+        base_url=base_url or cfg.ollama.base_url,
+        model=model or cfg.ollama.model,
+        timeout=cfg.ollama.timeout,
+    )
+
+    try:
+        new_cfg = AIConfig(
+            enabled=enable,
+            default_provider=provider,
+            ollama=ollama_cfg,
+            anthropic=cfg.anthropic,
+            openai=cfg.openai,
+        )
+    except Exception as e:
+        console.print(f"[red]✗ Invalid configuration:[/red] {str(e)}")
+        raise typer.Exit(code=1) from e
+
+    config_file = core_api.config_dir / "ai.toml"
+    toml_data = {
+        "ai": {
+            "enabled": new_cfg.enabled,
+            "default_provider": new_cfg.default_provider,
+            "providers": {
+                "ollama": new_cfg.ollama.model_dump(),
+                "anthropic": new_cfg.anthropic.model_dump(),
+                "openai": new_cfg.openai.model_dump(),
+            },
+        }
+    }
+
+    with open(config_file, "w", encoding="utf-8") as f:
+        toml.dump(toml_data, f)
+
+    core_api._ai_config = new_cfg
+
+    console.print(f"[green]✓[/green] AI config written to {config_file}")
+    console.print(f"  Enabled: {new_cfg.enabled}")
+    console.print(f"  Default provider: {new_cfg.default_provider}")
+    if new_cfg.default_provider == "ollama":
+        console.print(f"  Base URL: {new_cfg.ollama.base_url}")
+        console.print(f"  Model: {new_cfg.ollama.model}")
+
+
+@app.command(name="ai-status")
+def ai_status() -> None:
+    """
+    Show AI configuration and test connectivity to the configured provider.
+
+    Performs a connectivity check only - no case data is sent.
+    """
+    core_api = get_core_api()
+    cfg = core_api._ai_config
+
+    if not cfg.enabled:
+        console.print(
+            "[yellow]AI features disabled.[/yellow] Run [bold]yaft ai-configure --enable[/bold]."
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        provider = core_api.get_llm_provider()
+    except AIProviderNotImplementedError as e:
+        console.print(f"[yellow]{e}[/yellow]")
+        raise typer.Exit(code=1) from e
+
+    if provider.is_available():
+        console.print(f"[green]✓[/green] {cfg.default_provider} reachable ({cfg.ollama.model})")
+    else:
+        console.print(
+            f"[red]✗[/red] Could not reach {cfg.default_provider} at {cfg.ollama.base_url}"
+        )
+        console.print(
+            f"[dim]Is `ollama serve` running? Did you `ollama pull {cfg.ollama.model}`?[/dim]"
+        )
         raise typer.Exit(code=1)
 
 

--- a/src/yaft/core/ai_config.py
+++ b/src/yaft/core/ai_config.py
@@ -1,0 +1,68 @@
+"""
+AI / LLM provider configuration for YAFT.
+
+Defines the pydantic configuration models loaded from config/ai.toml. AI
+features are disabled by default and default to a local, self-hosted
+backend (Ollama or any OpenAI-compatible server) so that forensic case
+data never has to leave the examiner's machine unless a cloud provider
+is explicitly enabled.
+"""
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class OllamaProviderConfig(BaseModel):
+    """Configuration for a local, OpenAI-compatible backend (Ollama, llama.cpp, LM Studio, etc.)."""
+
+    base_url: str = Field(
+        default="http://localhost:11434/v1",
+        description="Base URL of the OpenAI-compatible server",
+    )
+    model: str = Field(default="llama3.1:8b", description="Model name to use")
+    timeout: int = Field(default=60, description="Request timeout in seconds")
+
+    @field_validator("timeout")
+    @classmethod
+    def validate_timeout(cls, v: int) -> int:
+        """Validate timeout."""
+        if v < 1:
+            raise ValueError("timeout must be >= 1")
+        return v
+
+
+class AnthropicProviderConfig(BaseModel):
+    """Placeholder configuration for the Anthropic provider (not yet implemented)."""
+
+    enabled: bool = Field(default=False, description="Whether the Anthropic provider is enabled")
+    model: str = Field(default="claude-haiku-4-5", description="Model name to use")
+
+
+class OpenAIProviderConfig(BaseModel):
+    """Placeholder configuration for the OpenAI provider (not yet implemented)."""
+
+    enabled: bool = Field(default=False, description="Whether the OpenAI provider is enabled")
+    model: str = Field(default="gpt-4o-mini", description="Model name to use")
+
+
+class AIConfig(BaseModel):
+    """AI / LLM provider configuration model."""
+
+    enabled: bool = Field(default=False, description="Whether AI features are enabled")
+    default_provider: str = Field(
+        default="ollama", description="Default provider (ollama, anthropic, openai)"
+    )
+    ollama: OllamaProviderConfig = Field(default_factory=OllamaProviderConfig)
+    anthropic: AnthropicProviderConfig = Field(default_factory=AnthropicProviderConfig)
+    openai: OpenAIProviderConfig = Field(default_factory=OpenAIProviderConfig)
+
+    @field_validator("default_provider")
+    @classmethod
+    def validate_default_provider(cls, v: str) -> str:
+        """Validate default provider."""
+        valid_providers = {"ollama", "anthropic", "openai"}
+        v_lower = v.lower()
+        if v_lower not in valid_providers:
+            raise ValueError(
+                f"Invalid default_provider: {v}. Must be one of {sorted(valid_providers)}"
+            )
+        return v_lower

--- a/src/yaft/core/api.py
+++ b/src/yaft/core/api.py
@@ -123,6 +123,9 @@ class CoreAPI:
         # Load plugin updater configuration
         self._plugin_updater_config = self._load_plugin_updater_config()
 
+        # Load AI / LLM provider configuration
+        self._ai_config = self._load_ai_config()
+
         # Storage for shared data between plugins
         self._shared_data: dict[str, Any] = {}
 
@@ -218,6 +221,69 @@ class CoreAPI:
             self.console.print(f"[bold yellow][WARNING][/bold yellow] Failed to load plugin updater config: {e}")
             self.console.print("[bold yellow][WARNING][/bold yellow] Using default plugin updater configuration")
             return PluginUpdaterConfig()
+
+    def _load_ai_config(self) -> Any:
+        """
+        Load AI / LLM provider configuration from TOML file.
+
+        Returns:
+            AIConfig: Loaded configuration or default config if file doesn't exist
+        """
+        from yaft.core.ai_config import (
+            AIConfig,
+            AnthropicProviderConfig,
+            OllamaProviderConfig,
+            OpenAIProviderConfig,
+        )
+
+        config_file = self.config_dir / "ai.toml"
+
+        if not config_file.exists():
+            # Return default configuration
+            return AIConfig()
+
+        try:
+            with open(config_file, encoding="utf-8") as f:
+                config_data = toml.load(f)
+
+            # Extract ai section
+            ai_section = config_data.get("ai", {})
+
+            # Extract nested provider sections
+            providers_section = ai_section.get("providers", {})
+            ollama_section = providers_section.get("ollama", {})
+            anthropic_section = providers_section.get("anthropic", {})
+            openai_section = providers_section.get("openai", {})
+
+            # Build config components
+            ollama_config = (
+                OllamaProviderConfig(**ollama_section) if ollama_section else OllamaProviderConfig()
+            )
+            anthropic_config = (
+                AnthropicProviderConfig(**anthropic_section)
+                if anthropic_section
+                else AnthropicProviderConfig()
+            )
+            openai_config = (
+                OpenAIProviderConfig(**openai_section) if openai_section else OpenAIProviderConfig()
+            )
+
+            # Remove nested dict and build main config
+            main_config = {k: v for k, v in ai_section.items() if k != "providers"}
+            main_config["ollama"] = ollama_config
+            main_config["anthropic"] = anthropic_config
+            main_config["openai"] = openai_config
+
+            return AIConfig(**main_config)
+        except Exception as e:
+            # If config is invalid, print warning and use defaults
+            self.console.print(
+                f"[bold yellow][WARNING][/bold yellow] Failed to load AI config: {e}"
+            )
+            self.console.print(
+                "[bold yellow][WARNING][/bold yellow] Using default AI configuration"
+            )
+            return AIConfig()
 
     def _setup_logging(self) -> None:
         """Configure logging based on loaded configuration."""
@@ -3976,6 +4042,36 @@ class CoreAPI:
         )
 
     # ========================================================================
+    # AI / LLM Provider Methods
+    # ========================================================================
+
+    def get_llm_provider(self) -> Any:
+        """
+        Get the configured LLM provider.
+
+        Uses configuration from config/ai.toml. Defaults to a local,
+        self-hosted backend (Ollama) since forensic case data often cannot
+        leave the examiner's machine. Cloud providers (Anthropic, OpenAI)
+        are opt-in and not yet implemented.
+
+        Returns:
+            LLMProvider instance for the configured default provider
+
+        Raises:
+            AIFeatureDisabledError: If AI features are disabled in config/ai.toml
+            AIProviderNotImplementedError: If the configured provider (anthropic,
+                openai) has no implementation yet
+
+        Example:
+            provider = self.core_api.get_llm_provider()
+            if provider.is_available():
+                result = provider.summarize("some text")
+        """
+        from yaft.ai.factory import build_provider
+
+        return build_provider(self._ai_config)
+
+    # ========================================================================
     # API Documentation
     # ========================================================================
 
@@ -4016,6 +4112,7 @@ class CoreAPI:
             "Encoding & Decoding": [],
             "Configuration": [],
             "Plugin System": [],
+            "AI / LLM": [],
             "User Input": [],
             "Shared Data": [],
         }
@@ -4086,6 +4183,8 @@ class CoreAPI:
                     methods_by_category["Configuration"].append(method_info)
                 elif "plugin" in name or "updater" in name:
                     methods_by_category["Plugin System"].append(method_info)
+                elif "llm" in name or name.startswith("ai_"):
+                    methods_by_category["AI / LLM"].append(method_info)
                 elif "input" in name or "confirm" in name or "prompt" in name:
                     methods_by_category["User Input"].append(method_info)
                 elif "shared_data" in name:

--- a/tests/test_ai_config.py
+++ b/tests/test_ai_config.py
@@ -1,0 +1,128 @@
+"""
+Tests for AI / LLM provider configuration.
+
+Tests the AIConfig pydantic model and CoreAPI._load_ai_config() including
+defaults, TOML loading/merging, and validation of default_provider.
+"""
+
+import pytest
+
+from yaft.core.ai_config import (
+    AIConfig,
+    AnthropicProviderConfig,
+    OllamaProviderConfig,
+    OpenAIProviderConfig,
+)
+from yaft.core.api import CoreAPI
+
+
+def test_ai_config_defaults():
+    """Test AIConfig default values."""
+    cfg = AIConfig()
+
+    assert cfg.enabled is False
+    assert cfg.default_provider == "ollama"
+    assert cfg.ollama.base_url == "http://localhost:11434/v1"
+    assert cfg.ollama.model == "llama3.1:8b"
+    assert cfg.ollama.timeout == 60
+    assert cfg.anthropic.enabled is False
+    assert cfg.openai.enabled is False
+
+
+def test_ollama_provider_config_defaults():
+    """Test OllamaProviderConfig default values."""
+    cfg = OllamaProviderConfig()
+
+    assert cfg.base_url == "http://localhost:11434/v1"
+    assert cfg.model == "llama3.1:8b"
+    assert cfg.timeout == 60
+
+
+def test_ollama_provider_config_invalid_timeout():
+    """Test OllamaProviderConfig rejects non-positive timeout."""
+    with pytest.raises(ValueError):
+        OllamaProviderConfig(timeout=0)
+
+
+def test_anthropic_provider_config_is_placeholder():
+    """Test AnthropicProviderConfig defaults to disabled."""
+    cfg = AnthropicProviderConfig()
+
+    assert cfg.enabled is False
+    assert cfg.model == "claude-haiku-4-5"
+
+
+def test_openai_provider_config_is_placeholder():
+    """Test OpenAIProviderConfig defaults to disabled."""
+    cfg = OpenAIProviderConfig()
+
+    assert cfg.enabled is False
+    assert cfg.model == "gpt-4o-mini"
+
+
+def test_ai_config_invalid_default_provider():
+    """Test AIConfig rejects unknown default_provider values."""
+    with pytest.raises(ValueError):
+        AIConfig(default_provider="bogus")
+
+
+def test_ai_config_valid_providers():
+    """Test AIConfig accepts all documented provider names."""
+    for provider in ("ollama", "anthropic", "openai"):
+        cfg = AIConfig(default_provider=provider)
+        assert cfg.default_provider == provider
+
+
+def test_load_ai_config_file_missing(tmp_path):
+    """Test loading AI config returns defaults when file doesn't exist."""
+    config_dir = tmp_path / "config"
+    api = CoreAPI(config_dir=config_dir)
+
+    assert isinstance(api._ai_config, AIConfig)
+    assert api._ai_config.enabled is False
+    assert api._ai_config.default_provider == "ollama"
+
+
+def test_load_ai_config_from_toml(tmp_path):
+    """Test loading AI config from a TOML file merges nested sections."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True)
+    (config_dir / "ai.toml").write_text(
+        """
+[ai]
+enabled = true
+default_provider = "ollama"
+
+[ai.providers.ollama]
+base_url = "http://localhost:9999/v1"
+model = "custom-model"
+timeout = 90
+""",
+        encoding="utf-8",
+    )
+
+    api = CoreAPI(config_dir=config_dir)
+
+    assert api._ai_config.enabled is True
+    assert api._ai_config.default_provider == "ollama"
+    assert api._ai_config.ollama.base_url == "http://localhost:9999/v1"
+    assert api._ai_config.ollama.model == "custom-model"
+    assert api._ai_config.ollama.timeout == 90
+
+
+def test_load_ai_config_invalid_toml_falls_back_to_defaults(tmp_path):
+    """Test that an invalid AI config file falls back to defaults with a warning."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True)
+    (config_dir / "ai.toml").write_text(
+        """
+[ai]
+default_provider = "not-a-real-provider"
+""",
+        encoding="utf-8",
+    )
+
+    api = CoreAPI(config_dir=config_dir)
+
+    assert isinstance(api._ai_config, AIConfig)
+    assert api._ai_config.default_provider == "ollama"

--- a/tests/test_ai_providers.py
+++ b/tests/test_ai_providers.py
@@ -1,0 +1,128 @@
+"""
+Tests for LLM provider implementations and the provider factory.
+
+Tests OpenAICompatibleProvider (used for Ollama and other OpenAI-compatible
+backends) with mocked HTTP calls, and build_provider()'s disabled/
+not-implemented error paths.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from yaft.ai.exceptions import (
+    AIFeatureDisabledError,
+    AIProviderError,
+    AIProviderNotImplementedError,
+)
+from yaft.ai.factory import build_provider
+from yaft.ai.providers.base import LLMResult
+from yaft.ai.providers.openai_compatible import OpenAICompatibleProvider
+from yaft.core.ai_config import AIConfig
+
+
+@pytest.fixture
+def provider():
+    """Create an OpenAICompatibleProvider for testing."""
+    return OpenAICompatibleProvider(
+        base_url="http://localhost:11434/v1",
+        model="llama3.1:8b",
+        timeout=10,
+    )
+
+
+@patch("yaft.ai.providers.openai_compatible.requests.get")
+def test_is_available_true(mock_get, provider):
+    """Test is_available returns True when the backend responds 200."""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_get.return_value = mock_response
+
+    assert provider.is_available() is True
+    mock_get.assert_called_once_with("http://localhost:11434/v1/models", timeout=5)
+
+
+@patch("yaft.ai.providers.openai_compatible.requests.get")
+def test_is_available_false_on_bad_status(mock_get, provider):
+    """Test is_available returns False on a non-200 status code."""
+    mock_response = Mock()
+    mock_response.status_code = 500
+    mock_get.return_value = mock_response
+
+    assert provider.is_available() is False
+
+
+@patch("yaft.ai.providers.openai_compatible.requests.get")
+def test_is_available_false_on_network_error(mock_get, provider):
+    """Test is_available returns False when the request raises."""
+    mock_get.side_effect = requests.ConnectionError("Connection refused")
+
+    assert provider.is_available() is False
+
+
+@patch("yaft.ai.providers.openai_compatible.requests.post")
+def test_summarize_success(mock_post, provider, tmp_path, monkeypatch):
+    """Test summarize returns an LLMResult on a successful call."""
+    monkeypatch.chdir(tmp_path)
+
+    mock_response = Mock()
+    mock_response.raise_for_status = Mock()
+    mock_response.json.return_value = {
+        "choices": [{"message": {"content": "Hello, world!"}}]
+    }
+    mock_post.return_value = mock_response
+
+    result = provider.summarize("say hello", system="be terse")
+
+    assert isinstance(result, LLMResult)
+    assert result.text == "Hello, world!"
+    assert result.provider == "ollama"
+    assert result.model == "llama3.1:8b"
+    assert result.latency_ms >= 0
+
+    # Audit log should contain no prompt/response content
+    audit_log = tmp_path / ".ai_cache" / "audit.jsonl"
+    assert audit_log.exists()
+    contents = audit_log.read_text(encoding="utf-8")
+    assert "say hello" not in contents
+    assert "Hello, world!" not in contents
+    assert '"success": true' in contents
+
+
+@patch("yaft.ai.providers.openai_compatible.requests.post")
+def test_summarize_network_error_raises(mock_post, provider, tmp_path, monkeypatch):
+    """Test summarize raises AIProviderError on a network failure."""
+    monkeypatch.chdir(tmp_path)
+    mock_post.side_effect = requests.ConnectionError("Connection refused")
+
+    with pytest.raises(AIProviderError):
+        provider.summarize("say hello")
+
+
+def test_build_provider_disabled_raises():
+    """Test build_provider raises AIFeatureDisabledError when disabled."""
+    cfg = AIConfig(enabled=False)
+
+    with pytest.raises(AIFeatureDisabledError):
+        build_provider(cfg)
+
+
+def test_build_provider_ollama_returns_openai_compatible():
+    """Test build_provider returns an OpenAICompatibleProvider for ollama."""
+    cfg = AIConfig(enabled=True, default_provider="ollama")
+
+    result = build_provider(cfg)
+
+    assert isinstance(result, OpenAICompatibleProvider)
+    assert result.model == cfg.ollama.model
+    assert result.base_url == cfg.ollama.base_url.rstrip("/")
+
+
+@pytest.mark.parametrize("provider_name", ["anthropic", "openai"])
+def test_build_provider_not_implemented_providers_raise(provider_name):
+    """Test build_provider raises AIProviderNotImplementedError for cloud providers."""
+    cfg = AIConfig(enabled=True, default_provider=provider_name)
+
+    with pytest.raises(AIProviderNotImplementedError):
+        build_provider(cfg)

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -93,6 +93,17 @@ def test_get_api_methods_zip_handling_category(core_api):
     assert "list_zip_contents" in method_names
 
 
+def test_get_api_methods_ai_llm_category(core_api):
+    """Test that AI / LLM category contains get_llm_provider."""
+    methods = core_api.get_api_methods()
+
+    assert "AI / LLM" in methods
+    ai_methods = methods["AI / LLM"]
+
+    method_names = [m["name"] for m in ai_methods]
+    assert "get_llm_provider" in method_names
+
+
 def test_get_api_methods_no_private_methods(core_api):
     """Test that private methods are not included."""
     methods = core_api.get_api_methods()


### PR DESCRIPTION
## Summary

This PR introduces an experimental, pluggable LLM provider abstraction to YAFT with a working local backend (Ollama and OpenAI-compatible servers) and full CLI/configuration wiring. AI features are disabled by default and default to local-only execution to ensure forensic case data never leaves the examiner's machine unless explicitly configured.

## Key Changes

- **AI Configuration System** (`src/yaft/core/ai_config.py`): Pydantic models for AI provider configuration with validation. Supports Ollama (default, local), Anthropic, and OpenAI (placeholders, not yet implemented). Configuration loaded from `config/ai.toml` with sensible defaults.

- **Provider Factory & Base Types** (`src/yaft/ai/factory.py`, `src/yaft/ai/providers/base.py`): Factory function to build configured providers. Base protocol defines `is_available()` and `summarize()` interface.

- **OpenAI-Compatible Provider** (`src/yaft/ai/providers/openai_compatible.py`): Working implementation for Ollama, llama.cpp, LM Studio, LocalAI, and vLLM. Includes minimal audit logging (timestamps, latency, success/failure only—never logs prompt/response content).

- **Exception Hierarchy** (`src/yaft/ai/exceptions.py`): Clear error types for disabled features, unimplemented providers, and provider failures.

- **CLI Commands** (`src/yaft/cli.py`):
  - `ai-configure`: Configure provider, model, base URL, and enable/disable AI features
  - `ai-status`: Check configuration and test connectivity (no case data sent)

- **CoreAPI Integration** (`src/yaft/core/api.py`): 
  - `_load_ai_config()`: Loads and merges TOML configuration with defaults
  - `get_llm_provider()`: Public API to retrieve configured provider instance
  - API documentation categorization for AI/LLM methods

- **Configuration File** (`config/ai.toml`): Example configuration with detailed comments explaining the local-first, opt-in design.

- **Comprehensive Tests** (`tests/test_ai_config.py`, `tests/test_ai_providers.py`): 
  - Configuration validation, defaults, and TOML loading
  - Provider availability checks and summarization with mocked HTTP
  - Error paths (disabled features, unimplemented providers)
  - Audit log verification

- **Documentation** (`docs/YaFT.md`, `README.md`): Usage examples and design rationale.

## Notable Implementation Details

- **Local-first design**: Ollama is the default provider; cloud providers (Anthropic, OpenAI) have config placeholders but raise `AIProviderNotImplementedError` if selected, with a clear message directing users to the local backend.
- **Audit logging**: Minimal, privacy-preserving logs record only metadata (timestamp, provider, model, latency, success flag)—never prompt or response content.
- **Graceful degradation**: Invalid AI config files fall back to defaults with a warning rather than crashing.
- **No case data sent yet**: This is plumbing only; no plugin currently sends forensic data to a model.

https://claude.ai/code/session_018MrbNYDqa5eLQdKyvYuTjD